### PR TITLE
Double / Single DQN functionallity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Results
+results/
+
 # Distribution / packaging
 .Python
 build/

--- a/agents/dqn_agent.py
+++ b/agents/dqn_agent.py
@@ -8,11 +8,15 @@ from utils.replay_buffer import ReplayBuffer
 class DQNAgent:
     def __init__(self, state_size: int, action_size: int, seed: int = 0,
                  buffer_size: int = int(1e5), batch_size: int = 64, gamma: float = 0.99,
-                 lr: float = 1e-3, tau: float = 1e-3, update_every: int = 4) -> None:
+                 lr: float = 1e-3, tau: float = 1e-3, update_every: int = 4, use_double_dqn:
+                 bool = True) -> None:
 
         self.state_size = state_size
         self.action_size = action_size
         self.seed = np.random.seed(seed)
+
+        # Double or Single DQN Flag
+        self.use_double_dqn = use_double_dqn
 
         # Q-Networks
         self.qnetwork_local = QNetwork(state_size, action_size, fc1_dims=64, fc2_dims=64).to("cpu")
@@ -58,7 +62,16 @@ class DQNAgent:
 
         # Get max predicted Q values (for next states) from target model
         with torch.no_grad():
-            q_targets_next = self.qnetwork_target(next_states).max(1)[0].unsqueeze(1)
+            # Branch for single or double DQN
+            if self.use_double_dqn:
+                #Double
+                next_actions = self.qnetwork_local(next_states).argmax(1).unsqueeze(1)
+                q_targets_next = self.qnetwork_local(next_states).gather(1, next_actions)
+            else:
+                #Vanilla
+                q_targets_next = self.qnetwork_target(next_states).max(1)[0].unsqueeze(1)
+        
+
 
         # Compute Q targets for current states
         q_targets = rewards + (self.gamma * q_targets_next * (1 - dones))

--- a/agents/dqn_agent.py
+++ b/agents/dqn_agent.py
@@ -8,15 +8,15 @@ from utils.replay_buffer import ReplayBuffer
 class DQNAgent:
     def __init__(self, state_size: int, action_size: int, seed: int = 0,
                  buffer_size: int = int(1e5), batch_size: int = 64, gamma: float = 0.99,
-                 lr: float = 1e-3, tau: float = 1e-3, update_every: int = 4, use_double_dqn:
-                 bool = True) -> None:
+                 lr: float = 1e-3, tau: float = 1e-3, update_every: int = 4, double_flag:
+                 bool = False) -> None:
 
         self.state_size = state_size
         self.action_size = action_size
         self.seed = np.random.seed(seed)
 
         # Double or Single DQN Flag
-        self.use_double_dqn = use_double_dqn
+        self.double_flag = double_flag
 
         # Q-Networks
         self.qnetwork_local = QNetwork(state_size, action_size, fc1_dims=64, fc2_dims=64).to("cpu")
@@ -63,7 +63,7 @@ class DQNAgent:
         # Get max predicted Q values (for next states) from target model
         with torch.no_grad():
             # Branch for single or double DQN
-            if self.use_double_dqn:
+            if self.double_flag:
                 #Double
                 next_actions = self.qnetwork_local(next_states).argmax(1).unsqueeze(1)
                 q_targets_next = self.qnetwork_local(next_states).gather(1, next_actions)

--- a/main.py
+++ b/main.py
@@ -41,28 +41,40 @@ def train(env: gym.Env, agent: DQNAgent, n_episodes: int = 1000, max_t: int = 10
 
     logger.save_plots()
     logger.save_metrics()
+    logger.save_summary()
     return logger.scores
 
 # Parses arguments
 def parse_args() -> Namespace:
     parser = argparse.ArgumentParser(description="TCSS 435 Lunar Lander")
+    parser.add_argument("--run_one", action="store_true",
+                        help="Run only double or single DQN. Defaults to both.")
     parser.add_argument("--double", action="store_true",
-                        help="Use double DQN instead of single DQN. Defaults to single.")
+                        help="Applies if --run_one is used. Use double DQN instead of single DQN. Defaults to single.")
     return parser.parse_args()
 
 # Main method
 def main() -> None:
+    """Main program"""
     args: Namespace = parse_args()
-    double_flag: bool = args.double
-    env: gym.Env = gym.make("LunarLander-v3")
-    state_size: int = env.observation_space.shape[0] # type: ignore
-    action_size: int = env.action_space.n # type: ignore
 
-    agent: DQNAgent = DQNAgent(state_size, action_size, double_flag=double_flag)
-    print(f"{'Double DQN' if double_flag else 'Single DQN'} is being used.")
-    scores: list[float] = train(env, agent, render_last=True, double_flag=double_flag)
+    def run_training(double_flag: bool):
+        env: gym.Env = gym.make("LunarLander-v3")
+        state_size: int = env.observation_space.shape[0] # type: ignore
+        action_size: int = env.action_space.n # type: ignore
+        agent: DQNAgent = DQNAgent(state_size, action_size, double_flag=double_flag)
+        print(f"{'Double DQN' if double_flag else 'Single DQN'} is being used.")
+        scores: list[float] = train(env, agent, render_last=True, double_flag=double_flag)
+        env.close()
 
-    env.close()
+    if args.run_one:
+        #Only runs the specified model
+        run_training(double_flag=args.double)
+    else:
+        run_training(double_flag=False) #Single DQN
+        run_training(double_flag=True) #Double DQN
+    
+
 
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     state_size = env.observation_space.shape[0] # type: ignore
     action_size = env.action_space.n # type: ignore
 
-    agent = DQNAgent(state_size, action_size)
+    agent = DQNAgent(state_size, action_size, use_double_dqn=True)
     scores = train(env, agent, render_last=True)
 
     env.close()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import gymnasium as gym
 import numpy as np
+import argparse
+from argparse import Namespace
 from agents.dqn_agent import DQNAgent
 from utils.train_logger import TrainLogger
 from typing import SupportsFloat, Tuple, Any
@@ -8,8 +10,8 @@ from tqdm import tqdm
 
 def train(env: gym.Env, agent: DQNAgent, n_episodes: int = 1000, max_t: int = 1000,
           eps_start: float = 1.0, eps_end: float = 0.01, eps_decay: float = 0.995,
-          render_last: bool = False) -> list[float]:
-    logger = TrainLogger(printer=tqdm.write)
+          render_last: bool = False, double_flag: bool = False) -> list[float]:
+    logger = TrainLogger(printer=tqdm.write, double_flag=double_flag)
     eps = eps_start
 
     for i_episode in tqdm(range(1, n_episodes + 1)):
@@ -41,13 +43,26 @@ def train(env: gym.Env, agent: DQNAgent, n_episodes: int = 1000, max_t: int = 10
     logger.save_metrics()
     return logger.scores
 
+# Parses arguments
+def parse_args() -> Namespace:
+    parser = argparse.ArgumentParser(description="TCSS 435 Lunar Lander")
+    parser.add_argument("--double", action="store_true",
+                        help="Use double DQN instead of single DQN. Defaults to single.")
+    return parser.parse_args()
 
-if __name__ == "__main__":
-    env = gym.make("LunarLander-v3")
-    state_size = env.observation_space.shape[0] # type: ignore
-    action_size = env.action_space.n # type: ignore
+# Main method
+def main() -> None:
+    args: Namespace = parse_args()
+    double_flag: bool = args.double
+    env: gym.Env = gym.make("LunarLander-v3")
+    state_size: int = env.observation_space.shape[0] # type: ignore
+    action_size: int = env.action_space.n # type: ignore
 
-    agent = DQNAgent(state_size, action_size, use_double_dqn=True)
-    scores = train(env, agent, render_last=True)
+    agent: DQNAgent = DQNAgent(state_size, action_size, double_flag=double_flag)
+    print(f"{'Double DQN' if double_flag else 'Single DQN'} is being used.")
+    scores: list[float] = train(env, agent, render_last=True, double_flag=double_flag)
 
     env.close()
+
+if __name__ == "__main__":
+    main()

--- a/utils/train_logger.py
+++ b/utils/train_logger.py
@@ -4,11 +4,12 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 
 class TrainLogger:
-    def __init__(self, save_dir: str = "results", printer: Callable[[str], None] = print) -> None:
+    def __init__(self, save_dir: str = "results", printer: Callable[[str], None] = print, double_flag: bool = False) -> None:
         self.scores: List[float] = []
         self.successes: List[int] = []
         self.save_dir = save_dir
         self.print = printer
+        self.double_flag: bool = double_flag
         os.makedirs(save_dir, exist_ok=True)
 
     def log(self, episode: int, score: float, success: bool) -> None:
@@ -20,15 +21,16 @@ class TrainLogger:
     def save_plots(self) -> None:
         """Create and save reward + success plots."""
         sns.set(style="darkgrid")
+        dqn_type: str = "double" if self.double_flag else "single"
 
         # Reward plot
         plt.figure()
         plt.plot(self.scores, label="Reward per Episode")
         plt.xlabel("Episode")
         plt.ylabel("Reward")
-        plt.title("DQN Reward Over Time")
+        plt.title(f"{'Double' if self.double_flag else 'Single'} DQN Reward Over Time")
         plt.legend()
-        plt.savefig(os.path.join(self.save_dir, "reward_plot.png"))
+        plt.savefig(os.path.join(self.save_dir, f"reward_plot_{dqn_type}.png"))
         plt.close()
 
         # Success rate (moving average)
@@ -39,7 +41,7 @@ class TrainLogger:
         plt.ylabel("Success Rate")
         plt.title("LunarLander Success Rate")
         plt.legend()
-        plt.savefig(os.path.join(self.save_dir, "success_plot.png"))
+        plt.savefig(os.path.join(self.save_dir, f"success_plot_{dqn_type}.png"))
         plt.close()
 
     def _moving_average(self, data: List[int], window: int = 20) -> List[float]:


### PR DESCRIPTION
Now implements a choice between double and single DQN or both. Defaults to both, otherwise defaults to single DQN, use "--run_one" to only run one. Use "--double" flag with run_one to use only double. Also updated some of the plot labeling to reflect single/double dqn in use. Now has a summary of the last 100 episodes (mean, median, mode, stdev, high, low, success rate).